### PR TITLE
Remove lonely script closing tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,8 +18,6 @@ layout: compress
 
     {{ content }}
 
-    </script>
-
     <div class="page__footer">
       <footer>
         {% include footer/custom.html %}


### PR DESCRIPTION
There appears to be no opening tag for this. Found using [validator.w3.org](https://validator.w3.org/nu/?doc=https%3A%2F%2Facademicpages.github.io%2F)