### PR TITLE
Address future deprecation warnings.

### DIFF
--- a/_sass/vendor/susy/susy/output/support/_support.scss
+++ b/_sass/vendor/susy/susy/output/support/_support.scss
@@ -67,7 +67,7 @@
 
     @each $_type, $_req in $requirements {
       @each $_i in $_req {
-        $_pass: call(unquote("#{$_type}-exists"), $_i);
+        $_pass: call(get-function(unquote("#{$_type}-exists")), $_i);
 
         @if not($_pass) {
           $_fail: true;


### PR DESCRIPTION
Modify a .scss file to address warnings of form 
``DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal in Sass 4.0. Use call(get-function("mixin-exists")) instead.``