### PR TITLE
Address deprecation warnings and Liquid related errors.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -255,7 +255,7 @@ timezone: America/Los_Angeles # http://en.wikipedia.org/wiki/List_of_tz_database
 
 
 # Plugins
-gems:
+plugins:
   - jekyll-paginate
   - jekyll-sitemap
   - jekyll-gist

--- a/_layouts/talk.html
+++ b/_layouts/talk.html
@@ -4,7 +4,7 @@ layout: default
 
 {% include base_path %}
 
-{% if (page.header.overlay_color or page.header.overlay_image) or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
   {% include page__hero.html %}
 {% endif %}
 

--- a/_sass/vendor/susy/susy/output/support/_support.scss
+++ b/_sass/vendor/susy/susy/output/support/_support.scss
@@ -67,7 +67,7 @@
 
     @each $_type, $_req in $requirements {
       @each $_i in $_req {
-        $_pass: call(unquote("#{$_type}-exists"), $_i);
+        $_pass: call(get-function(unquote("#{$_type}-exists")), $_i);
 
         @if not($_pass) {
           $_fail: true;


### PR DESCRIPTION
Fixed the following warnings & errors:

`DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal in Sass 4.0. Use call(get-function("...")) instead.`

`Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/talk.html`

`Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly."`