### PR TITLE
Fixing broken code block icon

### DIFF
--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -18,7 +18,7 @@ div.highlighter-rouge, figure.highlight {
     padding: 0.5em;
     background-color: $lighter-gray;
     content: "\f121";
-    font-family: "fontawesome" !important;
+    font-family: "Font Awesome 5 Free" !important;
     font-size: $type-size-6;
     line-height: 1;
     text-transform: none;


### PR DESCRIPTION
Font family name changed with fontawesome 5, breaking the old unicode content