### PR TITLE
Remove Google+

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -97,7 +97,6 @@ author:
   facebook         :
   foursquare       :
   github           : "academicpages"
-  google_plus      :
   keybase          :
   instagram        :
   impactstory      : #"https://profiles.impactstory.org/u/xxxx-xxxx-xxxx-xxxx"

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -7,7 +7,6 @@ Name Name:
   bio         : "This is the first name."
   avatar      : "bio-photo-2.jpg"
   twitter     : "name"
-  google_plus : "Name"
 
 Name2 Name2:
   name        : "Name2 Name2"
@@ -15,4 +14,3 @@ Name2 Name2:
   bio         : "I ordered what?"
   avatar      : "bio-photo.jpg"
   twitter     : "name2"
-  google_plus : "Name"

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -46,9 +46,6 @@
       {% if author.facebook %}
         <li><a href="https://www.facebook.com/{{ author.facebook }}"><i class="fab fa-fw fa-facebook-square" aria-hidden="true"></i> Facebook</a></li>
       {% endif %}
-      {% if author.google_plus %}
-        <li><a href="https://plus.google.com/+{{ author.google_plus }}"><i class="fab fa-fw fa-google-plus" aria-hidden="true"></i> Google+</a></li>
-      {% endif %}
       {% if author.linkedin %}
         <li><a href="https://www.linkedin.com/in/{{ author.linkedin }}"><i class="fab fa-fw fa-linkedin" aria-hidden="true"></i> LinkedIn</a></li>
       {% endif %}


### PR DESCRIPTION
Remove Google+ option from config and author profile. Google+ was shut down for
business use and consumers on April 2, 2019. https://en.wikipedia.org/wiki/Google%2B