### PR TITLE
fix font awesome code icon in syntax box

### DIFF
--- a/_sass/_syntax.scss
+++ b/_sass/_syntax.scss
@@ -18,7 +18,7 @@ div.highlighter-rouge, figure.highlight {
     padding: 0.5em;
     background-color: $lighter-gray;
     content: "\f121";
-    font-family: "fontawesome" !important;
+    font-family: "Font Awesome 5 Free" !important;
     font-size: $type-size-6;
     line-height: 1;
     text-transform: none;


### PR DESCRIPTION
The Font Awesome code icon (</>) at the top right of syntax boxes is not rendering and appears as a blank unicode box.

<img width="784" alt="Screen Shot 2020-06-20 at 9 38 42 AM" src="https://user-images.githubusercontent.com/12078284/85204162-827efc00-b2e0-11ea-887e-d31c23e8f32b.png">

Based on this [SO answer](https://stackoverflow.com/a/20782415/), I've changed `font-family: "fontawesome" !important;` to `font-family: "Font Awesome 5 Free" !important;` in `_sass/_syntax.scss` and it's now working for me.

<img width="788" alt="Screen Shot 2020-06-20 at 9 36 07 AM" src="https://user-images.githubusercontent.com/12078284/85204177-9aef1680-b2e0-11ea-834d-1227f8cc939d.png">

I've referenced this fix in #388.