### PR TITLE
bib-to-markdown encoding issue

### DIFF
--- a/markdown_generator/PubsFromBib.ipynb
+++ b/markdown_generator/PubsFromBib.ipynb
@@ -182,7 +182,7 @@
     "\n",
     "            md_filename = os.path.basename(md_filename)\n",
     "\n",
-    "            with open(\"../_publications/\" + md_filename, 'w') as f:\n",
+    "            with open(\"../_publications/\" + md_filename, 'w', encoding=\"utf-8\") as f:\n",
     "                f.write(md)\n",
     "            print(f'SUCESSFULLY PARSED {bib_id}: \\\"', b[\"title\"][:60],\"...\"*(len(b['title'])>60),\"\\\"\")\n",
     "        # field may not exist for a reference\n",

--- a/markdown_generator/pubsFromBib.py
+++ b/markdown_generator/pubsFromBib.py
@@ -151,7 +151,7 @@ for pubsource in publist:
 
             md_filename = os.path.basename(md_filename)
 
-            with open("../_publications/" + md_filename, 'w') as f:
+            with open("../_publications/" + md_filename, 'w', encoding="utf-8") as f:
                 f.write(md)
             print(f'SUCESSFULLY PARSED {bib_id}: \"', b["title"][:60],"..."*(len(b['title'])>60),"\"")
         # field may not exist for a reference


### PR DESCRIPTION
Thanks for this great project! This PR is for a bug with the bib-to-markdown conversion script.

When there are non-standard unicode characters in the bib file, jekyll will throw a parse error when parsing the resulting markdown files:

``Error: could not read file [...].md: invalid byte sequence in UTF-8``
