### PR TITLE
Fix Google Scholar link on publications page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,12 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 
-gem "github-pages", group: :jekyll_plugins
+ gem 'github-pages', '~> 214', group: :jekyll_plugins
 
 # If you want to use Jekyll native, uncomment the line below.
 # To upgrade, run `bundle update`.
 
-# gem "jekyll"
+  gem "jekyll"
 
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -4,6 +4,9 @@ title: "Publications"
 permalink: /publications/
 author_profile: true
 ---
+{% if page.author and site.data.authors[page.author] %}
+  {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.author %}
+{% endif %}
 
 {% if author.googlescholar %}
   You can also find my articles on <u><a href="{{author.googlescholar}}">my Google Scholar profile</a>.</u>


### PR DESCRIPTION
Copying the author assignment lines from _includes/author_profile.html is a simple way to solve the variable scope issue that (I believe) seems to be why the link isn't showing.

I suggest this is a slightly better solution than #474 and #545 as it doesn't break multi-author support on the default version of the publications page.