### PR TITLE
Add webrick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,3 +25,5 @@ group :jekyll_plugins do
   gem 'jekyll-sitemap'
   gem 'hawkins'
 end
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
Running on Linux fails without [webrick](https://github.com/ruby/webrick/) installed. 

```
$ bundle exec jekyll liveserve                
Configuration file: /home/signmaker/local/academicpages.github.io/_config.yml                  
            Source: /home/signmaker/local/academicpages.github.io  
       Destination: /home/signmaker/local/academicpages.github.io/_site                                                                                                                       
 Incremental build: disabled. Enable with --incremental                                        
      Generating...                            
       Jekyll Feed: Generating feed for posts                                                  
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.                                                                           
                    done in 4.893 seconds.                                                     
 Auto-regeneration: enabled for '/home/signmaker/local/academicpages.github.io'
Configuration file: /home/signmaker/local/academicpages.github.io/_config.yml                  
/home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/servlet.rb:1:in `require': cannot load such file -- webrick (LoadError)                 
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/servlet.rb:1:in `<top (required)>'                                         
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/liveserve.rb:116:in `require_relative'                                     
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/liveserve.rb:116:in `setup'                                                
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/liveserve.rb:60:in `process'                                               
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/liveserve.rb:54:in `start'                                                 
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/hawkins-2.0.5/lib/hawkins/liveserve.rb:43:in `block (2 levels) in init_with_program'                 
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'                                   
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'                                               
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'                                            
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'                                                  
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'                                                     
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/gems/jekyll-3.9.2/exe/jekyll:15:in `<top (required)>'                                                     
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/bin/jekyll:25:in `load'                                                                                   
        from /home/signmaker/local/academicpages.github.io/vendor/bundle/ruby/3.0.0/bin/jekyll:25:in `<main>'
```

We run `gem add webrick` and commit the result.