### PR TITLE
Resolve Google Scholar link not displayed

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -5,8 +5,8 @@ permalink: /publications/
 author_profile: true
 ---
 
-{% if author.googlescholar %}
-  You can also find my articles on <u><a href="{{author.googlescholar}}">my Google Scholar profile</a>.</u>
+{% if site.author.googlescholar %}
+  You can also find my articles on <u><a href="{{site.author.googlescholar}}">my Google Scholar profile</a>.</u>
 {% endif %}
 
 {% include base_path %}


### PR DESCRIPTION
There was as slight typo in the logic due to which the google scholar link for the respective author's profile set in Config was not being displayed.