### PR TITLE
Pin Jekyll version < 3.9.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "github-pages", group: :jekyll_plugins
 # To upgrade, run `bundle update`.
 
 # gem "jekyll"
+gem 'jekyll', "< 3.9.2"  # This line was added in order to pin jekyll to a stable version (it is broken >= 3.9.2).
 
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 


### PR DESCRIPTION
Running liveserve fails with error "NoMethodError: undefined method key? for nil:NilClass in conditionally_inject_charset" on all GET requests, which seems to be caused by Jekyll 3.9.2.

Resolves https://github.com/academicpages/academicpages.github.io/issues/943.