### PR TITLE
Comment alexa_site_verification

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,7 +52,7 @@ atom_feed:
 # SEO Related
 google_site_verification :
 bing_site_verification   :
-alexa_site_verification  :
+#alexa_site_verification  : Amazon retired Alexa May 1, 2022
 yandex_site_verification :
 
 # Social Sharing


### PR DESCRIPTION
Amazon retired Alexa search on May 1st, 2022.
I propose removing the alexa_site_verification configuration from the _config.yml file.