### PR TITLE
Add Google Analytics 4 Support (Issue #1152)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -73,7 +73,7 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "google-universal" # false (default), "google", "google-universal", "custom"
+  provider               :  "google-universal" # false (default), "google", "google-universal", "google-analytics-4", "custom"
   google:
     tracking_id          :
 

--- a/_includes/analytics-providers/google-analytics-4.html
+++ b/_includes/analytics-providers/google-analytics-4.html
@@ -1,0 +1,8 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{site.analytics.google.tracking_id}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{site.analytics.google.tracking_id}}');
+</script>

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -5,6 +5,8 @@
   {% include /analytics-providers/google.html %}
 {% when "google-universal" %}
   {% include /analytics-providers/google-universal.html %}
+{% when "google-analytics-4" %}
+  {% include /analytics-providers/google-analytics-4.html %}
 {% when "custom" %}
   {% include /analytics-providers/custom.html %}
 {% endcase %}


### PR DESCRIPTION
Google [announced](https://support.google.com/analytics/answer/10089681?hl=en) that on July 1st, 2023 they will no longer process Universal Analytics data and users should transition to Google Analytics 4 by this point. Currently, the only way I'm aware of to add support for google analytics 4 in this repo is to modify the template in _includes/analytics-providers/custom.html. 

As users may wish to have this feature supported in the _config.yml, (see [Issue #1152](https://github.com/academicpages/academicpages.github.io/issues/1152), I added an extra analytics template and allowed the user to specify their analytics provider in _config.yml. I have not changed the default provider in _config.yml to google analytics 4. If you think that is appropriate at this time please feel free to add that.

Please let me know if you encounter any bugs. Additional comments are also welcome.