### PR TITLE
Added Scroll Functionality to Sidebar

### DIFF
--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -11,7 +11,7 @@
           transform: translate3d(0, 0 , 0);
 
   height: 100vh;
-  overflow-y: auto;
+  overflow-y: auto; // Scroll sidebar content
 
   @include clearfix();
   margin-bottom: 1em;

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -10,6 +10,9 @@
   -webkit-transform: translate3d(0, 0 , 0);
           transform: translate3d(0, 0 , 0);
 
+  height: 100vh;
+  overflow-y: auto;
+
   @include clearfix();
   margin-bottom: 1em;
 


### PR DESCRIPTION
This pull request adds scroll functionality to the sidebar. This is achieved by setting the height of the sidebar to 100vh and enabling overflow-y to auto. This ensures that the sidebar is always the full height of the viewport, and if the content exceeds this height, the user can scroll down to see the rest of the content. This improves the user experience by making navigation easier and more intuitive.