### PR TITLE
Fix typo in build-essential package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ When you are initially working your website, it is very useful to be able to pre
 1. Run `bundle install` to install ruby dependencies. If you get errors, delete Gemfile.lock and try again.
 1. Run `jekyll serve -l -H localhost` to generate the HTML and serve it from `localhost:4000` the local server will automatically rebuild and refresh the pages on change.
 
-If you are running on Linux it may be necessary to install some additional dependencies prior to being able to run locally: `sudo apt install build-essentials gcc make`
+If you are running on Linux it may be necessary to install some additional dependencies prior to being able to run locally: `sudo apt install build-essential gcc make`
 
 # Maintenance 
 


### PR DESCRIPTION
The package which is required for this installation is named `build-essential`, not `build-essentials`.