### PR TITLE
Fix broken analytics default in `_config.yml` 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -137,7 +137,7 @@ social:
 
 # Analytics
 analytics:
-  provider               :  "google-universal" # false (default), "google", "google-universal", "google-analytics-4", "custom"
+  provider               :  "false" # false (default), "google", "google-universal", "google-analytics-4", "custom"
   google:
     tracking_id          :
 


### PR DESCRIPTION
The config claims the default analytics provider to be `"false"` instead it is `"google-universal"`

https://github.com/academicpages/academicpages.github.io/blob/5c5669901adeb67136ac3217a091233ac24e9f82/_config.yml#L140

This pull request fixes this. 