### PR TITLE
Fixing YouTube URL generation in author-profile.html

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -148,7 +148,7 @@
         <li><a href="https://www.xing.com/profile/{{ author.xing }}"><i class="fab fa-fw fa-xing icon-pad-right" aria-hidden="true"></i>XING</a></li>
       {% endif %}
       {% if author.youtube %}
-        <li><a href="https://www.youtube.com/user/{{ author.youtube }}"><i class="fab fa-fw fa-youtube icon-pad-right" aria-hidden="true"></i>YouTube</a></li>
+        <li><a href="https://www.youtube.com/@{{ author.youtube }}"><i class="fab fa-fw fa-youtube icon-pad-right" aria-hidden="true"></i>YouTube</a></li>
       {% endif %}
       {% if author.zhihu %}
       <li><a href="{{ author.zhihu }}"><i class="fab fa-fw fa-zhihu icon-pad-right" aria-hidden="true"></i>Zhihu</a></li>


### PR DESCRIPTION
YouTube does not use /user/username at the moment. If a person has a YouTube handle, the URL is: www.youtube.com/@HANDLE

The fix is very minimal but I needed it for my website so I've also added it here.