### PR TITLE
Add Twitter, Facebook back to footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,10 +1,16 @@
 {% include base_path %}
 
-{% if site.author.github or site.author.bitbucket or site.atom_feed.hide != true %}
+{% if site.twitter.username or site.facebook.username or site.author.github or site.author.bitbucket or site.atom_feed.hide != true %}
 <div class="page__footer-follow">
   <ul class="social-icons">
     {% if site.data.ui-text[site.locale].follow_label %}
       <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
+    {% endif %}
+    {% if site.twitter.username %}
+      <li><a href="https://twitter.com/{{ site.twitter.username }}"><i class="fab fa-x-twitter" aria-hidden="true"></i> X (formerly Twitter)</a></li>
+    {% endif %}
+    {% if site.facebook.username %}
+      <li><a href="https://facebook.com/{{ site.facebook.username }}"><i class="fab fa-facebook-square" aria-hidden="true"></i> Facebook</a></li>
     {% endif %}
     {% if site.author.github %}
       <li><a href="http://github.com/{{ site.author.github }}"><i class="fab fa-github" aria-hidden="true"></i> GitHub</a></li>


### PR DESCRIPTION
https://github.com/academicpages/academicpages.github.io/commit/2a269d2fae2c5a2313e5fa7afa809fec79385d9f mistakenly removed the Twitter and Facebook following options. I have added these back.

I tested this works by setting variables and verified the Follow section does not show up if all of these socials are not in the config.