### PR TITLE
Fix custom comments appearing at bottom of page

### DIFF
--- a/_includes/comments.html
+++ b/_includes/comments.html
@@ -76,6 +76,8 @@
       {% endif %}
     </section>
   {% when "custom" %}
+    <h4 class="page__comments-title">{{ comments_label }}</h4>
     <section id="comments"></section>
+    {% include /comments-providers/scripts.html %}
   {% endcase %}
 </div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,3 @@
 <script src="{{ base_path }}/assets/js/main.min.js"></script>
 
 {% include analytics.html %}
-{% include /comments-providers/scripts.html %}


### PR DESCRIPTION
Custom comments are currently inserted incorrectly into the page. I have fixed custom comments to behave the same as other comments providers by putting them in the comments section.
