### PR TITLE
Fix toc crop (#221)

### DIFF
--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -405,6 +405,7 @@
     font-weight: bold;
     line-height: 1.5;
     border-bottom: 1px solid $border-color;
+    text-decoration-line: none !important;
 
     &:hover {
       color: #000;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -132,9 +132,9 @@ $x-large                    : 1280px !default;
    Grid
    ========================================================================== */
 
-$right-sidebar-width-narrow : 0px;
-$right-sidebar-width        : 0px;
-$right-sidebar-width-wide   : 0px;
+$right-sidebar-width-narrow : 200px !default;
+$right-sidebar-width        : 300px !default;
+$right-sidebar-width-wide   : 400px !default;
 
 $susy: (
   columns: 12,


### PR DESCRIPTION
This toc visual issue still exists https://github.com/academicpages/academicpages.github.io/issues/221#issuecomment-483970772.
Upstreaming the fix from #221. This code fixes the problem as confirmed by #706.

I have also removed underlining of toc links, which was being overridden by post body css.