### PR TITLE
Fix padding misalignment

### DIFF
--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -27,9 +27,9 @@
     @include clearfix;
     margin-left: auto;
     margin-right: auto;
-    margin-top: 2em;
+    margin-top: 1em;
     max-width: 100%;
-    padding: 0 1em 2em;
+    padding: 0 1em 1em;
 
     @include breakpoint($x-large) {
       max-width: $x-large;

--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -52,7 +52,7 @@
   white-space: nowrap;
 
   &--lg {
-    padding-right: 3em;
+    padding-right: 2em;
     font-weight: 700;
   }
 }


### PR DESCRIPTION
Fixed a regression in the template updates where the navigation bar no longer aligns with the post left margin at normal viewport.

Reduced excessive footer padding.