### PR TITLE
Slides URL fix in "archive-single.html" includes template

### DIFF
--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -63,7 +63,7 @@
     {% elsif post.paperurl %}
       <p><a href=" {{ post.paperurl }} ">Download Paper</a></p>
     {% elsif post.slidesurl %}
-      <p>Download <a href="{{ post.slidesurl }}">Download Slides</a></p></p>
+      <p><a href="{{ post.slidesurl }}">Download Slides</a></p>
     {% endif %}
 
   </article>


### PR DESCRIPTION
In the "archive-single" include, the "Download" word is repeated twice in the case when only a slidesURL is given.  
An extra paragraph ending is also mistakenly present.
This pull request's proposed modifications solve these issues.
