### PR TITLE
Fix typo in Zhihu URL protocol in `_includes/author-profile.html`

### DIFF
--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -154,7 +154,7 @@
         <li><a href="https://www.youtube.com/@{{ author.youtube }}"><i class="fab fa-fw fa-youtube icon-pad-right" aria-hidden="true"></i>YouTube</a></li>
       {% endif %}
       {% if author.zhihu %}
-      <li><a href="htps://www.zhihu.com/people/{{ author.zhihu }}"><i class="fab fa-fw fa-zhihu icon-pad-right" aria-hidden="true"></i>Zhihu</a></li>
+      <li><a href="https://www.zhihu.com/people/{{ author.zhihu }}"><i class="fab fa-fw fa-zhihu icon-pad-right" aria-hidden="true"></i>Zhihu</a></li>
       {% endif %}      
     </ul>
   </div>


### PR DESCRIPTION
This PR corrects a minor typo in the Zhihu URL protocol in the `author-profile.html` file. 
The protocol was written as `htp` instead of `https`. This change ensures the correct URL format for Zhihu links.