### PR TITLE
Fixed non-working "redirect_from"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :jekyll_plugins do
   gem 'jekyll'
   gem 'jekyll-feed'
   gem 'jekyll-sitemap'
+  gem 'jekyll-redirect-from'
   gem 'jemoji'
   gem 'webrick', '~> 1.8'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -302,6 +302,7 @@ plugins:
   - jekyll-gist
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-redirect-from
   - jemoji
 
 # Mimic GitHub Pages with --safe
@@ -310,6 +311,7 @@ whitelist:
   - jekyll-gist
   - jekyll-paginate
   - jekyll-sitemap
+  - jekyll-redirect-from
   - jemoji
 
 


### PR DESCRIPTION
Added: 
jekyll-redirect-from to Gemfile, 
 - jekyll-redirect-from to _config.yml under 'plugins:' and 'whitelist:'

After fix applied, redirects work properly again.