### PR TITLE
Improved color contrast for link text

### DIFF
--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -72,7 +72,7 @@ $primary-color              : #7a8288;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
-$info-color                 : #52adc8;
+$info-color                 : #236070;
 
 /* brands */
 $behance-color              : #1769FF;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -72,7 +72,7 @@ $primary-color              : #7a8288;
 $success-color              : #62c462;
 $warning-color              : #f89406;
 $danger-color               : #ee5f5b;
-$info-color                 : #236070;
+$info-color                 : #2f7f93;
 
 /* brands */
 $behance-color              : #1769FF;


### PR DESCRIPTION
Per Web Content Accessibility Guidelines (WCAG), [text content should have a minimum contrast](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html) of at least **4.5:1** (or **3:1** for large text). The links on the pages have a default light blue color (i.e., `#52adc8`). This color, when contrasting against the white background color (i.e., `#ffffff`), [yields a color contrast of **2.57:1**](https://webaim.org/resources/contrastchecker/?fcolor=52ADC8&bcolor=FFFFFF), which is insufficient to pass the minimum contrast threshold. As a result, users who have low vision or visual disabilities may have trouble perceiving the link text.

<p align="center"><img src="https://github.com/user-attachments/assets/b3fac8c7-621b-4efb-92f6-42b53bf953c7" width=85%></p>



I fixed this issue by changing the link color to a darker shade of the same light blue. Using WebAIM’s Contrast Checker, I found that the color `#236070` is the equivalent darker shade ([yielding a color contrast of **7.05:1**](https://webaim.org/resources/contrastchecker/?fcolor=236070&bcolor=FFFFFF)) that passes the enhanced contrast at WCAG Level AAA standard.

<p align="center"><img src="https://github.com/user-attachments/assets/b4a890f0-9ac1-4d1f-bb66-a0faa237b5f2" width=85%></p>



I modified the `$info-color` property on file ‎`_sass/_variables.scss`, and the built changes were automatically reflected as `a{color:#236070}` under `_site/assets/css/main.css` on my forked repo.

I don't know if this color is still what the designer originally intended. It might be too close to the base black text, but since the [links are styled to be underlined, making them distinguishable](https://webaim.org/techniques/hypertext/link_text), I am not worried about this color for my own site. Please don't hesitate to suggest another color with sufficient color contrast. Thanks!