### PR TITLE
Update for scrapping talk location through github actions

### DIFF
--- a/.github/    workflows  /scrape_talks.yml
+++ b/.github/    workflows  /scrape_talks.yml
@@ -1,0 +1,36 @@
+name: Scrape Talk Locations
+
+on:
+  push:
+    paths:
+      - 'talks/**'
+      - 'talkmap.ipynb'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'  # Specify the Python version you need
+
+    - name: Install dependencies
+      run: |
+        pip install jupyter pandas requests beautifulsoup4 geopy  # Add other dependencies as needed
+        pip install getorg --upgrade
+
+    - name: Run Jupyter Notebook
+      run: |
+        jupyter nbconvert --to notebook --execute talkmap.ipynb --output talkmap_out.ipynb
+
+    - name: Commit changes
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add .
+        git commit -m "Automated update of talk locations" || echo "No changes to commit"
+        git push

--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ breadcrumbs              : false # true, false (default)
 words_per_minute         : 160
 future                   : true
 read_more                : "disabled" # if enabled, adds "Read more" links to excerpts
-talkmap_link             : true #change to true to add link to talkmap on talks page
+talkmap_link             : false      #change to true to add link to talkmap on talks page
 comments:
   provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
   disqus:

--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ breadcrumbs              : false # true, false (default)
 words_per_minute         : 160
 future                   : true
 read_more                : "disabled" # if enabled, adds "Read more" links to excerpts
-talkmap_link             : false #change to true to add link to talkmap on talks page
+talkmap_link             : true #change to true to add link to talkmap on talks page
 comments:
   provider               : # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman", "custom"
   disqus:


### PR DESCRIPTION
Added a github action workflow that runs the provided jupyter notebook that scrapes the talks locations from the talk entries and updates the talkmap accordingly.