### PR TITLE
update readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ When you are initially working your website, it is very useful to be able to pre
     ```bash
     sudo apt install ruby-dev ruby-bundler nodejs
     ```
+    If you see error `Unable to locate package ruby-bundler`, `Unable to locate package nodejs `, run the following:
+    ```bash
+    sudo apt update && sudo apt upgrade -y
+    ```
+    then try run `sudo apt install ruby-dev ruby-bundler nodejs` again.
+
     On MacOS the commands are:
     ```bash
     brew install ruby
@@ -33,7 +39,16 @@ When you are initially working your website, it is very useful to be able to pre
     gem install bundler
     ```
 1. Run `bundle install` to install ruby dependencies. If you get errors, delete Gemfile.lock and try again.
+
+    If you see file permission error like `Fetching bundler-2.6.3.gem ERROR:  While executing gem (Gem::FilePermissionError) You don't have write permissions for the /var/lib/gems/3.2.0 directory.` or `Bundler::PermissionError: There was an error while trying to write to /usr/local/bin.`
+    Install Gems Locally (Recommended):
+    ```bash
+    bundle config set --local path 'vendor/bundle'
+    ```
+    then try run `bundle install` again. If succeeded, you should see a folder called `vendor` and open `.gitignore` then add `vendor` inside it.
+
 1. Run `jekyll serve -l -H localhost` to generate the HTML and serve it from `localhost:4000` the local server will automatically rebuild and refresh the pages on change.
+    You may also try `bundle exec jekyll serve -l -H localhost` to ensure jekyll to use specific dependencies on your own local machine.
 
 If you are running on Linux it may be necessary to install some additional dependencies prior to being able to run locally: `sudo apt install build-essential gcc make`
 


### PR DESCRIPTION
Hi there~

My name is Yuhao and you may just call me nickname Libra...

**I post my own solution when I set the environment to run on my local machine.**

**My OS is Windows 10
Working with VScode**

## Below is some overview:
1. When I was first calling `sudo apt install ruby-dev ruby-bundler nodejs`, the terminal returned `unable to locate package`.
    ```bash
    Reading package lists... Done  
    Building dependency tree... Done 
    Reading state information... Done
    E: Unable to locate package ruby-bundler
    E: Unable to locate package nodejs  
    ```
    I fixed it by updating the package index. 

2. For some reason due to file permission and it is highly possible because of WSL setting, 
    ```bash
    ERROR:  While executing gem ... (Gem::FilePermissionError)
        You don't have write permissions for the /var/lib/gems/3.2.0 directory.
    ```
    ```bash
    Bundler::PermissionError: There was an error while trying to write to /usr/local/bin. It is likely that you need to grant write permissions for that path.
    ```
    I had to set the local path for the `bundle install`

3. I had gem version conflict
    ```bash
    /var/lib/gems/3.2.0/gems/bundler-2.6.3/lib/bundler/runtime.rb:319:in check_for_activated_spec!': You have already activated eventmachine 1.3.0.dev.1, but your Gemfile requires eventmachine 1.2.7. Prepending bundle exec to your command may solve this. (Gem::LoadError)
    ```
    and easy fix for this just ran `bundle exec jekyll serve -l -H localhost`

If you wanna see complete error message and I can add later~
Hopefully these will help other people who also work on Windows.

