### PR TITLE
Update .gitignore to prevent manual update site from fail to build using Github actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ Gemfile.lock
 node_modules
 package-lock.json
 
-# Ignore the vendor file and bundle for alternative installation
-vendor/
+# Ignore the vendor file at root level and bundle for alternative installation
+/vendor/
 .bundle/
 
 # Ignore folders related to IDEs


### PR DESCRIPTION
Quick fix for issue #3170 that causes the manual update site to fail to build when pushed to GitHub 