### PR TITLE
_includes/footer.html: Fix site last updated template

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -21,5 +21,5 @@
 
 <div class="page__footer-copyright">
   &copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }}, {{ site.data.ui-text[site.locale].powered_by | default: "Powered by" }} <a href="http://jekyllrb.com" rel="nofollow">Jekyll</a> &amp; <a href="https://github.com/academicpages/academicpages.github.io">AcademicPages</a>, a fork of <a href="https://mademistakes.com/work/minimal-mistakes-jekyll-theme/" rel="nofollow">Minimal Mistakes</a>.<br />
-  Site last updated {{ "now" | date: '%Y-%m-%d' %}}
+  Site last updated {{ "now" | date: '%Y-%m-%d' }}
 </div>


### PR DESCRIPTION
The original grammar of `{{ "now" | date: '%Y-%m-%d' %}}` looks like a typo. Fixing it by using the correct `{{ ... }}` grammar.