### PR TITLE
Made loading mathjax, plotly and mermaid optional for each page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -244,6 +244,9 @@ defaults:
       comments: true
       share: true
       related: true
+      plotly: true
+      mermaid: true
+      mathjax: true
   # _pages
   - scope:
       path: ""

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -3,17 +3,23 @@
 <a href="/sitemap/">Sitemap</a>
 
 <!-- Support for MatJax -->
-<script defer src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+ {% if page.mathjax %}
+    <script defer src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
+{% endif %}
 
 <!-- Support for Plotly -->
-<script defer src='https://cdnjs.cloudflare.com/ajax/libs/plotly.js/3.0.1/plotly.min.js'></script>
+{% if page.plotly %}
+    <script defer src='https://cdnjs.cloudflare.com/ajax/libs/plotly.js/3.0.1/plotly.min.js'></script>
+{% endif %}
 
 <!-- Support for Mermaid -->
-<script type="module">
-    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
-    mermaid.initialize({startOnLoad:true, theme:'default'});
-    await mermaid.run({querySelector:'code.language-mermaid'});
-</script>
+ {% if page.mermaid %}
+    <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+        mermaid.initialize({startOnLoad:true, theme:'default'});
+        await mermaid.run({querySelector:'code.language-mermaid'});
+    </script>
+{% endif %}
 
 <!-- end custom footer snippets -->


### PR DESCRIPTION
[Performance of the theme](https://github.com/academicpages/academicpages.github.io/issues/3151) could be greatly enhanced if support for MathJax, Plotly and Mermaid was enabled only when necessary. A simple way to do this would be to do in `_includes\footer\custom.html`
` {% if page.mathjax %}
    <script defer src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
    <script defer src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>
{% endif %}`
and set `mathjax: true` in the defaults of `_config.yml`. 

If a certain page does not require mathjax then the user could set `mathjax: false` in the YAML header of the page, thus saving a lot of JS runtime! All of this is also applicable for `plotly` and `mermaid`.

Personally, I'm setting by default `mathjax: false`. But this may complicate using the theme for new users.