### PR TITLE
_includes/head.html: Drop useless meta http-equiv="cleartype" tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,5 +17,3 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ base_path }}/assets/css/main.css">
-
-<meta http-equiv="cleartype" content="on">


### PR DESCRIPTION
This meta tag is only useful for pre-IE9 era and is now useless. For example, see the discussion on its removal a decade ago at https://www.drupal.org/project/drupal/issues/1717090 . We should not keep it anymore.