### PR TITLE
navicon: Use span instead of div inside button element

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -4,7 +4,7 @@
   <div class="masthead__inner-wrap">
     <div class="masthead__menu">
       <nav id="site-nav" class="greedy-nav">
-        <button><div class="navicon"></div></button>
+        <button><span class="navicon"></span></button>
         <ul class="visible-links">
           <li class="masthead__menu-item masthead__menu-item--lg persist"><a href="{{ base_path }}/">{{ site.title }}</a></li>
           {% for link in site.data.navigation.main %}

--- a/_sass/include/_utilities.scss
+++ b/_sass/include/_utilities.scss
@@ -325,6 +325,8 @@ body:hover .visually-hidden button {
 
 .navicon {
   position: relative;
+  display: inline-block;
+  vertical-align: middle;
   width: $navicon-width;
   height: $navicon-height;
   background: #fff;


### PR DESCRIPTION
Originally all generated pages have the following error in HTML validator (e.g., https://validator.w3.org/nu/):

```
Element div not allowed as child of element button in this context. (Suppressing further errors from this subtree.)

From line 1, column 2805; to line 1, column 2825

> <button><div class="navicon"></div>
```

We replace `<div>` with `<span>`, and also set `display: inline-block` to fix this validation error and not to alter the existing visual layout.