### PR TITLE
_includes/head.html: Remove meta tags HandheldFriendly, MobileOptimized

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,9 +6,6 @@
 
 <link href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ base_path }}/feed.xml{% endif %}" type="application/atom+xml" rel="alternate" title="{{ site.title }} Feed">
 
-<!-- http://t.co/dKP3o1e -->
-<meta name="HandheldFriendly" content="True">
-<meta name="MobileOptimized" content="320">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <script>


### PR DESCRIPTION
For the following tags in the HTML header:

```
<meta name="HandheldFriendly" content="True">
<meta name="MobileOptimized" content="320">
```

They are no longer useful for more than a decade. See https://github.com/mmistakes/minimal-mistakes/issues/1835 for a similar change and its discussion.

Also remove a comment that contains a shortened URL that points to an unknown, now broken Twitter/X post.