### PR TITLE
fix: hamburger menu theme switching

### DIFF
--- a/_sass/include/_utilities.scss
+++ b/_sass/include/_utilities.scss
@@ -329,7 +329,7 @@ body:hover .visually-hidden button {
   vertical-align: middle;
   width: $navicon-width;
   height: $navicon-height;
-  background: #fff;
+  background: var(--global-masthead-link-color);
   margin: auto;
   -webkit-transition: 0.3s;
   transition: 0.3s;
@@ -341,7 +341,7 @@ body:hover .visually-hidden button {
     left: 0;
     width: $navicon-width;
     height: $navicon-height;
-    background: #fff;
+    background: var(--global-masthead-link-color);
     -webkit-transition: 0.3s;
     transition: 0.3s;
   }

--- a/_sass/layout/_navigation.scss
+++ b/_sass/layout/_navigation.scss
@@ -196,7 +196,7 @@
     padding: 0 0.5rem;
     border: 0;
     outline: none;
-    background-color: var(--global-base-color);
+    background-color: var(--global-bg-color);
     color: #fff;
     cursor: pointer;
     z-index: 100;
@@ -268,7 +268,7 @@
     padding: 5px;
     border: 1px solid var(--global-border-color);
     border-radius: $border-radius;
-    background: #fff;
+    background: var(--global-bg-color);
     box-shadow: 0 0 10px rgba(#000, 0.25);
 
     a {
@@ -303,7 +303,7 @@
       width: 0;
       border-style: solid;
       border-width: 0 10px 10px;
-      border-color: #fff transparent;
+      border-color: var(--global-bg-color) transparent;
       display: block;
       z-index: 1;
     }


### PR DESCRIPTION
Make navicon icon and dropdown menu use theme-aware CSS variables instead of hardcoded colors for proper contrast in both light and dark modes

### Before

https://github.com/user-attachments/assets/c400e11f-6892-47e9-9366-62302ca341ed


### After 

https://github.com/user-attachments/assets/647b83ad-bff2-4d38-b5da-fa2fbc33d218

