### PR TITLE
Do not enable duplicated bottom margin/padding when js is enabled

### DIFF
--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -104,6 +104,7 @@ $(document).ready(function () {
 
   // Enable the sticky footer
   var bumpIt = function () {
+    $("body").css("padding-bottom", "0");
     $("body").css("margin-bottom", $(".page__footer").outerHeight(true));
   }
   $(window).resize(function () {


### PR DESCRIPTION
Ever wondered why there is such a big space at the bottom of the website when fully scrolled down?

<img width="1954" height="1608" alt="image" src="https://github.com/user-attachments/assets/8c9710fd-be37-4ef7-9570-db2e0fa7eaad" />


Current code enables an always-on `padding-bottom: 9em` for `body` element to avoid body contents to be blocked by footer banner.

However when javascript is enabled, the body element receives an extra `margin-bottom` that equals to the height of `page__footer` element. This causes extra `9em` of spaces at the bottom of each page.

This commit adds a line in the javascript resize monitor function, and always set the `padding-bottom` for body element to be `0` on window reload or window resizing. This eliminates the extra `9em` space at the bottom. In the meanwhile, the `9em `space is kept when javascript is disabled for the website, providing a bottom-line user experience in the js-disabled case.

(Let me know if you do not wish me to modify the `.min.js` file. I can revise my PR accordingly.)