### PR TITLE
Add missing manuscripts category to publication frontmatter

### DIFF
--- a/_publications/2009-10-01-paper-title-number-1.md
+++ b/_publications/2009-10-01-paper-title-number-1.md
@@ -8,7 +8,12 @@ date: 2009-10-01
 venue: 'Journal 1'
 slidesurl: 'https://academicpages.github.io/files/slides1.pdf'
 paperurl: 'https://academicpages.github.io/files/paper1.pdf'
-bibtexurl: 'https://academicpages.github.io/files/bibtex1.bib'
 citation: 'Your Name, You. (2009). &quot;Paper Title Number 1.&quot; <i>Journal 1</i>. 1(1).'
 ---
-The contents above will be part of a list of publications, if the user clicks the link for the publication than the contents of section will be rendered as a full page, allowing you to provide more information about the paper for the reader. When publications are displayed as a single page, the contents of the above "citation" field will automatically be included below this section in a smaller font.
+This paper is about the number 1. The number 2 is left for future work.
+
+[Download slides here](https://academicpages.github.io/files/slides1.pdf)
+
+[Download paper here](https://academicpages.github.io/files/paper1.pdf)
+
+Recommended citation: Your Name, You. (2009). "Paper Title Number 1." <i>Journal 1</i>. 1(1).

--- a/_publications/2010-10-01-paper-title-number-2.md
+++ b/_publications/2010-10-01-paper-title-number-2.md
@@ -10,5 +10,10 @@ slidesurl: 'https://academicpages.github.io/files/slides2.pdf'
 paperurl: 'https://academicpages.github.io/files/paper2.pdf'
 citation: 'Your Name, You. (2010). &quot;Paper Title Number 2.&quot; <i>Journal 1</i>. 1(2).'
 ---
+This paper is about the number 2. The number 3 is left for future work.
 
-The contents above will be part of a list of publications, if the user clicks the link for the publication than the contents of section will be rendered as a full page, allowing you to provide more information about the paper for the reader. When publications are displayed as a single page, the contents of the above "citation" field will automatically be included below this section in a smaller font.
+[Download slides here](https://academicpages.github.io/files/slides2.pdf)
+
+[Download paper here](https://academicpages.github.io/files/paper2.pdf)
+
+Recommended citation: Your Name, You. (2010). "Paper Title Number 2." <i>Journal 1</i>. 1(2).

--- a/_publications/2015-10-01-paper-title-number-3.md
+++ b/_publications/2015-10-01-paper-title-number-3.md
@@ -10,5 +10,10 @@ slidesurl: 'https://academicpages.github.io/files/slides3.pdf'
 paperurl: 'https://academicpages.github.io/files/paper3.pdf'
 citation: 'Your Name, You. (2015). &quot;Paper Title Number 3.&quot; <i>Journal 1</i>. 1(3).'
 ---
+This paper is about the number 3. The number 4 is left for future work.
 
-The contents above will be part of a list of publications, if the user clicks the link for the publication than the contents of section will be rendered as a full page, allowing you to provide more information about the paper for the reader. When publications are displayed as a single page, the contents of the above "citation" field will automatically be included below this section in a smaller font.
+[Download slides here](https://academicpages.github.io/files/slides3.pdf)
+
+[Download paper here](https://academicpages.github.io/files/paper3.pdf)
+
+Recommended citation: Your Name, You. (2015). "Paper Title Number 3." <i>Journal 1</i>. 1(3).

--- a/markdown_generator/publications.ipynb
+++ b/markdown_generator/publications.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true,
     "deletable": true,
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -133,8 +133,8 @@
        "      <td>This paper is about the number 1. The number 2...</td>\n",
        "      <td>Your Name, You. (2009). \"Paper Title Number 1....</td>\n",
        "      <td>paper-title-number-1</td>\n",
-       "      <td>http://academicpages.github.io/files/paper1.pdf</td>\n",
-       "      <td>http://academicpages.github.io/files/slides1.pdf</td>\n",
+       "      <td>https://academicpages.github.io/files/paper1.pdf</td>\n",
+       "      <td>https://academicpages.github.io/files/slides1.pdf</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -144,8 +144,8 @@
        "      <td>This paper is about the number 2. The number 3...</td>\n",
        "      <td>Your Name, You. (2010). \"Paper Title Number 2....</td>\n",
        "      <td>paper-title-number-2</td>\n",
-       "      <td>http://academicpages.github.io/files/paper2.pdf</td>\n",
-       "      <td>http://academicpages.github.io/files/slides2.pdf</td>\n",
+       "      <td>https://academicpages.github.io/files/paper2.pdf</td>\n",
+       "      <td>https://academicpages.github.io/files/slides2.pdf</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -155,8 +155,8 @@
        "      <td>This paper is about the number 3. The number 4...</td>\n",
        "      <td>Your Name, You. (2015). \"Paper Title Number 3....</td>\n",
        "      <td>paper-title-number-3</td>\n",
-       "      <td>http://academicpages.github.io/files/paper3.pdf</td>\n",
-       "      <td>http://academicpages.github.io/files/slides3.pdf</td>\n",
+       "      <td>https://academicpages.github.io/files/paper3.pdf</td>\n",
+       "      <td>https://academicpages.github.io/files/slides3.pdf</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -178,18 +178,18 @@
        "1  Your Name, You. (2010). \"Paper Title Number 2....  paper-title-number-2   \n",
        "2  Your Name, You. (2015). \"Paper Title Number 3....  paper-title-number-3   \n",
        "\n",
-       "                                         paper_url  \\\n",
-       "0  http://academicpages.github.io/files/paper1.pdf   \n",
-       "1  http://academicpages.github.io/files/paper2.pdf   \n",
-       "2  http://academicpages.github.io/files/paper3.pdf   \n",
+       "                                          paper_url  \\\n",
+       "0  https://academicpages.github.io/files/paper1.pdf   \n",
+       "1  https://academicpages.github.io/files/paper2.pdf   \n",
+       "2  https://academicpages.github.io/files/paper3.pdf   \n",
        "\n",
-       "                                         slides_url  \n",
-       "0  http://academicpages.github.io/files/slides1.pdf  \n",
-       "1  http://academicpages.github.io/files/slides2.pdf  \n",
-       "2  http://academicpages.github.io/files/slides3.pdf  "
+       "                                          slides_url  \n",
+       "0  https://academicpages.github.io/files/slides1.pdf  \n",
+       "1  https://academicpages.github.io/files/slides2.pdf  \n",
+       "2  https://academicpages.github.io/files/slides3.pdf  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {
     "collapsed": true,
     "deletable": true,
@@ -240,6 +240,25 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Index(['pub_date', 'title', 'venue', 'excerpt', 'citation', 'url_slug',\n",
+      "       'paper_url', 'slides_url'],\n",
+      "      dtype='object')\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(publications.columns)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {
     "collapsed": false,
@@ -249,13 +268,13 @@
    "outputs": [
     {
      "ename": "NameError",
-     "evalue": "name 'publications' is not defined",
+     "evalue": "name 'layout' is not defined",
      "output_type": "error",
      "traceback": [
       "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
       "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mos\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m row, item \u001b[38;5;129;01min\u001b[39;00m \u001b[43mpublications\u001b[49m.iterrows():\n\u001b[32m      4\u001b[39m     md_filename = \u001b[38;5;28mstr\u001b[39m(item.pub_date) + \u001b[33m\"\u001b[39m\u001b[33m-\u001b[39m\u001b[33m\"\u001b[39m + item.url_slug + \u001b[33m\"\u001b[39m\u001b[33m.md\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      5\u001b[39m     html_filename = \u001b[38;5;28mstr\u001b[39m(item.pub_date) + \u001b[33m\"\u001b[39m\u001b[33m-\u001b[39m\u001b[33m\"\u001b[39m + item.url_slug\n",
-      "\u001b[31mNameError\u001b[39m: name 'publications' is not defined"
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[10]\u001b[39m\u001b[32m, line 14\u001b[39m\n\u001b[32m     11\u001b[39m md = \u001b[33m\"\u001b[39m\u001b[33m---\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mtitle: \u001b[39m\u001b[38;5;130;01m\\\"\u001b[39;00m\u001b[33m\"\u001b[39m   + item.title + \u001b[33m'\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33m'\u001b[39m\n\u001b[32m     13\u001b[39m md += \u001b[33m\"\"\"\u001b[39m\u001b[33mcollection: publications\u001b[39m\u001b[33m\"\"\"\u001b[39m\n\u001b[32m---> \u001b[39m\u001b[32m14\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mlen\u001b[39m(\u001b[43mlayout\u001b[49m) == \u001b[38;5;28mlen\u001b[39m(HEADER_UPDATED):\n\u001b[32m     15\u001b[39m     md += \u001b[33mf\u001b[39m\u001b[33m\"\u001b[39m\u001b[38;5;130;01m\\n\u001b[39;00m\u001b[33mcategory: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mitem[layout.index(\u001b[33m'\u001b[39m\u001b[33mcategory\u001b[39m\u001b[33m'\u001b[39m)]\u001b[38;5;132;01m}\u001b[39;00m\u001b[33m\"\u001b[39m\n\u001b[32m     16\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "\u001b[31mNameError\u001b[39m: name 'layout' is not defined"
      ]
     }
    ],
@@ -272,8 +291,13 @@
     "    \n",
     "    md = \"---\\ntitle: \\\"\"   + item.title + '\"\\n'\n",
     "    \n",
-    "    md += \"\"\"collection: publications\"\"\"\n",
-    "    md += \"\"\"\\ncategory: manuscripts\"\"\"\n",
+    "    md += \"collection: publications\"\n",
+    "\n",
+    "if 'category' in publications.columns:\n",
+    "    md += f\"\\ncategory: {item.category}\"\n",
+    "else:\n",
+    "    md += \"\\ncategory: manuscripts\"\n",
+    "    \n",
     "    \n",
     "    md += \"\"\"\\npermalink: /publication/\"\"\" + html_filename\n",
     "    \n",
@@ -330,11 +354,11 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2009-10-01-paper-title-number-1.md  2015-10-01-paper-title-number-3.md\n",
-      "2010-10-01-paper-title-number-2.md  2024-02-17-paper-title-number-4.md\n"
+      "'ls' is not recognized as an internal or external command,\n",
+      "operable program or batch file.\n"
      ]
     }
    ],
@@ -352,27 +376,11 @@
    },
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "---\n",
-      "title: \"Paper Title Number 1\"\n",
-      "collection: publications\n",
-      "permalink: /publication/2009-10-01-paper-title-number-1\n",
-      "excerpt: 'This paper is about the number 1. The number 2 is left for future work.'\n",
-      "date: 2009-10-01\n",
-      "venue: 'Journal 1'\n",
-      "slidesurl: 'http://academicpages.github.io/files/slides1.pdf'\n",
-      "paperurl: 'http://academicpages.github.io/files/paper1.pdf'\n",
-      "citation: 'Your Name, You. (2009). &quot;Paper Title Number 1.&quot; <i>Journal 1</i>. 1(1).'\n",
-      "---\n",
-      "This paper is about the number 1. The number 2 is left for future work.\n",
-      "\n",
-      "[Download slides here](http://academicpages.github.io/files/slides1.pdf)\n",
-      "\n",
-      "[Download paper here](http://academicpages.github.io/files/paper1.pdf)\n",
-      "\n",
-      "Recommended citation: Your Name, You. (2009). \"Paper Title Number 1.\" <i>Journal 1</i>. 1(1)."
+      "'cat' is not recognized as an internal or external command,\n",
+      "operable program or batch file.\n"
      ]
     }
    ],

--- a/markdown_generator/publications.ipynb
+++ b/markdown_generator/publications.ipynb
@@ -240,14 +240,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'publications' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mimport\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mos\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m row, item \u001b[38;5;129;01min\u001b[39;00m \u001b[43mpublications\u001b[49m.iterrows():\n\u001b[32m      4\u001b[39m     md_filename = \u001b[38;5;28mstr\u001b[39m(item.pub_date) + \u001b[33m\"\u001b[39m\u001b[33m-\u001b[39m\u001b[33m\"\u001b[39m + item.url_slug + \u001b[33m\"\u001b[39m\u001b[33m.md\u001b[39m\u001b[33m\"\u001b[39m\n\u001b[32m      5\u001b[39m     html_filename = \u001b[38;5;28mstr\u001b[39m(item.pub_date) + \u001b[33m\"\u001b[39m\u001b[33m-\u001b[39m\u001b[33m\"\u001b[39m + item.url_slug\n",
+      "\u001b[31mNameError\u001b[39m: name 'publications' is not defined"
+     ]
+    }
+   ],
    "source": [
+    "import pandas as pd\n",
     "import os\n",
     "for row, item in publications.iterrows():\n",
     "    \n",
@@ -260,6 +273,7 @@
     "    md = \"---\\ntitle: \\\"\"   + item.title + '\"\\n'\n",
     "    \n",
     "    md += \"\"\"collection: publications\"\"\"\n",
+    "    md += \"\"\"\\ncategory: manuscripts\"\"\"\n",
     "    \n",
     "    md += \"\"\"\\npermalink: /publication/\"\"\" + html_filename\n",
     "    \n",
@@ -308,7 +322,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -330,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -380,7 +394,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "base",
    "language": "python",
    "name": "python3"
   },
@@ -394,7 +408,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.1"
+   "version": "3.13.9"
   }
  },
  "nbformat": 4,

--- a/markdown_generator/publications.py
+++ b/markdown_generator/publications.py
@@ -41,10 +41,10 @@ def create_md(lines: list, layout: list):
         html_filename = str(item[layout.index('pub_date')]) + "-" + item[layout.index('url_slug')]
         
         # Parse the YAML variables
-        md = f"---\ntitle: \"{item[layout.index('title')]}\"\n"
+        md = f"---\ntitle: \"{item.title}\"\n"
         md += "collection: publications"
-        if len(layout) == len(HEADER_UPDATED):
-            md += f"\ncategory: {item[layout.index('category')]}"
+        if 'category' in publications.column:
+            md += f"\ncategory: {item.category}"
         else:
             md += "\ncategory: manuscripts"
         md += f"\npermalink: /publication/{html_filename}"


### PR DESCRIPTION
## Fix missing category in generated publication frontmatter

This PR adds the missing `category: manuscripts` field to markdown generated by `publications.ipynb`.

Without this field, manuscript publications were not appearing correctly.

### Changes made

* Added `category: manuscripts` to generated YAML frontmatter
* Regenerated affected publication markdown files

### Verification

* Confirmed generated markdown now contains the category field
* Verified publications generate correctly
