### PR TITLE
fix talks.py: add CSV support, drop pandas dependency

### DIFF
--- a/markdown_generator/talks.py
+++ b/markdown_generator/talks.py
@@ -1,111 +1,91 @@
-
+#!/usr/bin/env python
 # coding: utf-8
 
-# # Talks markdown generator for academicpages
-# 
-# Takes a TSV of talks with metadata and converts them for use with [academicpages.github.io](academicpages.github.io). This is an interactive Jupyter notebook ([see more info here](http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html)). The core python code is also in `talks.py`. Run either from the `markdown_generator` folder after replacing `talks.tsv` with one containing your data.
-# 
-# TODO: Make this work with BibTex and other databases, rather than Stuart's non-standard TSV format and citation style.
+# Talks markdown generator for academicpages
+#
+# Takes a TSV or CSV of talks with metadata and converts them for use with
+# the academicpages GitHub Pages template.
+# Usage: python3 talks.py talks.tsv
+#        python3 talks.py talks.csv
+#        python3 talks.py talks.tsv _talks/
+#
+# Uses the Python standard library (csv) so it has no external dependencies.
 
-# In[1]:
-
-import pandas as pd
+import csv
 import os
-
-
-# ## Data format
-# 
-# The TSV needs to have the following columns: title, type, url_slug, venue, date, location, talk_url, description, with a header at the top. Many of these fields can be blank, but the columns must be in the TSV.
-# 
-# - Fields that cannot be blank: `title`, `url_slug`, `date`. All else can be blank. `type` defaults to "Talk" 
-# - `date` must be formatted as YYYY-MM-DD.
-# - `url_slug` will be the descriptive part of the .md file and the permalink URL for the page about the paper. 
-#     - The .md file will be `YYYY-MM-DD-[url_slug].md` and the permalink will be `https://[yourdomain]/talks/YYYY-MM-DD-[url_slug]`
-#     - The combination of `url_slug` and `date` must be unique, as it will be the basis for your filenames
-# 
-
-
-# ## Import TSV
-# 
-# Pandas makes this easy with the read_csv function. We are using a TSV, so we specify the separator as a tab, or `\t`.
-# 
-# I found it important to put this data in a tab-separated values format, because there are a lot of commas in this kind of data and comma-separated values can get messed up. However, you can modify the import statement, as pandas also has read_excel(), read_json(), and others.
-
-# In[3]:
-
-talks = pd.read_csv("talks.tsv", sep="\t", header=0)
-talks
-
-
-# ## Escape special characters
-# 
-# YAML is very picky about how it takes a valid string, so we are replacing single and double quotes (and ampersands) with their HTML encoded equivilents. This makes them look not so readable in raw format, but they are parsed and rendered nicely.
-
-# In[4]:
+import sys
 
 html_escape_table = {
     "&": "&amp;",
     '"': "&quot;",
     "'": "&apos;"
-    }
+}
 
 def html_escape(text):
-    if type(text) is str:
-        return "".join(html_escape_table.get(c,c) for c in text)
+    if isinstance(text, str):
+        return "".join(html_escape_table.get(c, c) for c in text)
     else:
-        return "False"
+        return ""
 
 
-# ## Creating the markdown files
-# 
-# This is where the heavy lifting is done. This loops through all the rows in the TSV dataframe, then starts to concatentate a big string (```md```) that contains the markdown for each type. It does the YAML metadata first, then does the description for the individual page.
+def main(input_file, output_dir=None):
+    if output_dir is None:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        output_dir = os.path.join(script_dir, "..", "_talks")
 
-# In[5]:
+    os.makedirs(output_dir, exist_ok=True)
 
-loc_dict = {}
+    ext = os.path.splitext(input_file)[1].lower()
+    delimiter = "\t" if ext in (".tsv", ".txt") else ","
 
-for row, item in talks.iterrows():
-    
-    md_filename = str(item.date) + "-" + item.url_slug + ".md"
-    html_filename = str(item.date) + "-" + item.url_slug 
-    year = item.date[:4]
-    
-    md = "---\ntitle: \""   + item.title + '"\n'
-    md += "collection: talks" + "\n"
-    
-    if len(str(item.type)) > 3:
-        md += 'type: "' + item.type + '"\n'
-    else:
-        md += 'type: "Talk"\n'
-    
-    md += "permalink: /talks/" + html_filename + "\n"
-    
-    if len(str(item.venue)) > 3:
-        md += 'venue: "' + item.venue + '"\n'
-        
-    if len(str(item.date)) > 3:
-        md += "date: " + str(item.date) + "\n"
-    
-    if len(str(item.location)) > 3:
-        md += 'location: "' + str(item.location) + '"\n'
-           
-    md += "---\n"
-    
-    
-    if len(str(item.talk_url)) > 3:
-        md += "\n[More information here](" + item.talk_url + ")\n" 
-        
-    
-    if len(str(item.description)) > 3:
-        md += "\n" + html_escape(item.description) + "\n"
-        
-        
-    md_filename = os.path.basename(md_filename)
-    #print(md)
-    
-    with open("../_talks/" + md_filename, 'w') as f:
-        f.write(md)
+    with open(input_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f, delimiter=delimiter)
+        for row in reader:
+            title = row.get("title", "").strip()
+            url_slug = row.get("url_slug", "").strip()
+            date = row.get("date", "").strip()
+            talk_type = row.get("type", "").strip()
+            venue = row.get("venue", "").strip()
+            location = row.get("location", "").strip()
+            talk_url = row.get("talk_url", "").strip()
+            description = row.get("description", "").strip()
+
+            if not title or not url_slug or not date:
+                print("Skipping row: missing required field (title, url_slug, or date)", file=sys.stderr)
+                continue
+
+            md_filename = date + "-" + url_slug + ".md"
+            md_path = os.path.join(output_dir, md_filename)
+
+            md = "---\n"
+            md += "title: \"" + title + "\"\n"
+            md += "collection: talks\n"
+            if len(talk_type) > 3:
+                md += 'type: "' + talk_type + '"\n'
+            else:
+                md += 'type: "Talk"\n'
+            md += "permalink: /talks/" + date + "-" + url_slug + "\n"
+            if venue:
+                md += 'venue: "' + venue + '"\n'
+            md += "date: " + date + "\n"
+            if location:
+                md += 'location: "' + location + '"\n'
+            md += "---\n"
+
+            if talk_url:
+                md += "\n[More information here](" + talk_url + ")\n"
+            if description:
+                md += "\n" + html_escape(description) + "\n"
+
+            with open(md_path, "w", encoding="utf-8") as out:
+                out.write(md)
+            print("Created: " + md_path)
 
 
-# These files are in the talks directory, one directory below where we're working from.
-
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 talks.py <input_file> [output_dir]")
+        sys.exit(1)
+    input_file = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+    main(input_file, output_dir)


### PR DESCRIPTION
Replaces pandas with stdlib csv so the script runs without extra packages, and adds CSV support alongside the existing TSV input.
Now accepts both TSV and CSV input files via extension detection.
Also adds CLI args so you can specify input file and output directory directly.
