### PR TITLE
feat: link translated post versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,37 @@
 
 See more info at https://academicpages.github.io/
 
+## Linking translated posts
+
+Posts can automatically link to their translations. Give every version the
+same `translation_key`, then set its language code and the label readers should
+see:
+
+```yaml
+---
+title: "Research update"
+lang: en
+language_label: English
+translation_key: research-update
+---
+```
+
+For example, a Chinese version can use the same key with different language
+metadata and its own permalink:
+
+```yaml
+---
+title: "研究进展"
+lang: zh
+language_label: 中文
+translation_key: research-update
+permalink: /zh/posts/research-update/
+---
+```
+
+When two or more posts share a key, the post layout displays links for every
+language version. Posts without a `translation_key` are unchanged.
+
 ### Additional Tutorials
 
 Additional tutorials for working with the Academic Pages template can be found at the following sites:

--- a/_includes/translation-switcher.html
+++ b/_includes/translation-switcher.html
@@ -1,0 +1,16 @@
+{% if page.translation_key %}
+  {% assign translations = site.posts | where: "translation_key", page.translation_key | sort: "lang" %}
+  {% if translations.size > 1 %}
+    <nav class="page__translation-switcher" aria-label="Language versions">
+      <span class="page__translation-switcher-label">Read in:</span>
+      {% for translation in translations %}
+        {% assign label = translation.language_label | default: translation.lang %}
+        {% if translation.url == page.url %}
+          <span lang="{{ translation.lang }}" aria-current="page">{{ label }}</span>
+        {% else %}
+          <a href="{{ translation.url | relative_url }}" lang="{{ translation.lang }}" hreflang="{{ translation.lang }}">{{ label }}</a>
+        {% endif %}
+      {% endfor %}
+    </nav>
+  {% endif %}
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@ layout: compress
 {% include base_path %}
 
 <!doctype html>
-<html lang="{{ site.locale | slice: 0,2 }}" class="no-js"{% if site.site_theme == "dark" %} data-theme="dark"{% endif %}>
+<html lang="{{ page.lang | default: site.locale | slice: 0,2 }}" class="no-js"{% if site.site_theme == "dark" %} data-theme="dark"{% endif %}>
   <head>
     {% include head.html %}
     {% include head/custom.html %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -45,6 +45,8 @@ layout: default
       {% endunless %}
 
       <section class="page__content" itemprop="text">
+        {% include translation-switcher.html %}
+
         {{ content }}
 
         {% if page.citation and page.paperurl and page.slidesurl and page.bibtexurl %}

--- a/_sass/layout/_page.scss
+++ b/_sass/layout/_page.scss
@@ -48,6 +48,27 @@
   font-size: $type-size-4;
 }
 
+.page__translation-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.5em;
+  margin: 0 0 1.5em;
+  padding: 0.65em 0.8em;
+  font-family: $sans-serif;
+  font-size: $type-size-6;
+  border-left: 3px solid var(--global-link-color);
+  background: var(--global-code-background-color);
+
+  [aria-current="page"] {
+    font-weight: bold;
+  }
+}
+
+.page__translation-switcher-label {
+  color: var(--global-text-color-light);
+}
+
 .page__content {
 
   h2 {


### PR DESCRIPTION
This is an enhancement or feature.

## Summary

Add an opt-in, build-time language switcher for translated blog posts. Posts that share a `translation_key` are discovered automatically from `site.posts`; each version supplies its standard `lang` code and a reader-facing `language_label`.

The switcher is theme-aware and accessible (`hreflang`, per-link `lang`, and `aria-current`). The page-level language also overrides the site locale on the root `<html lang>` attribute. Posts without translation metadata render exactly as before. README examples document the three front-matter fields.

## Context

No linked issue. This extracts a reusable multilingual pattern from a customized Academic Pages site without imposing English/Chinese filename rules, URL prefixes, generated data files, or JavaScript on template users.

## Verification

- Clean production Jekyll build with `--strict_front_matter` on Ruby 3.3
- Rendered two sample translations and verified reciprocal links, `hreflang`, `aria-current`, and page-specific `<html lang>` output

## Version

Branched from `482bc2b22db0500a12c2297d96ba5db44e1d0929`.