### PR TITLE
Fix the OS dark-mode preference being ignored on page load

### DIFF
--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -25,12 +25,10 @@ function determineComputedTheme() {
   return browserPref ? "dark" : "light";
 }
 
-// Set the theme on page load or when explicitly called
+// Set the theme on page load or when explicitly called. Without an argument the
+// theme is the stored preference or, failing that, the OS/browser preference.
 function setTheme(theme) {
-  const use_theme = theme ||
-    localStorage.getItem("theme") ||
-    $("html").attr("data-theme") ||
-    browserPref;
+  const use_theme = theme || determineComputedTheme();
 
   if (use_theme === "dark") {
     $("html").attr("data-theme", "dark");


### PR DESCRIPTION
This is a bug fix.

## Summary

Since 5d2ce16 (#3650) `browserPref` is a boolean, but `setTheme()` still used it as the last fallback of its `||` chain and compared the result with "dark"/"light". With no stored preference the comparison never matched, so the page stayed light even when the OS asks for dark, and the `prefers-color-scheme` change listener never had any effect on first load either.

Use `determineComputedTheme()`, which already implements the intended "stored preference, else OS preference" lookup, as the fallback.

(Please remember to regenerate `main.min.js` after merging this pull request.)

### User site-specific preference vs. default browser preference

Currently the buutton only allows 2 states: "dark" and "light". I think we should make it explicitly a tri-state case: "dark", "light" and "system". If you agree on that, I can make a follow-up PR to implement that.

## Version

ea56e24e8aadfdd06f2b42611be9f663290166fa