### PR TITLE
DRAFT: seperating devcontainer runtime from jekyll server

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,5 +11,6 @@
     ],
     "workspaceFolder": "/usr/src/app",
     "remoteUser": "vscode",
-    "forwardPorts": [4000] // Add port forwarding
+    "forwardPorts": [4000], // Add port forwarding
+    "postCreateCommand": "jekyll serve -H 0.0.0.0 -w --config _config.yml,_config_docker.yml"
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,4 +6,4 @@ services:
     ports: [ 4000:4000 ]
     user: 1000:1000
     environment: [ JEKYLL_ENV=docker ]
-    command: jekyll serve -H 0.0.0.0 -w --config _config.yml,_config_docker.yml
+    command: sleep infinity


### PR DESCRIPTION




 This is an enhancement or feature. 


## Summary

For starting the server directly in the container crashed for some reason and it was hard to debug and anyoing because I just wanted to make a small change. In the proposed way the risk of crashing the devContainer is minimized and restarting the jekyll server manually alows for easier debugging.

## Context
No Issue created, jumped directly to the implementation

## Version

ea56e24e8aadfdd06f2b42611be9f663290166fa

